### PR TITLE
docs(init): Add initial docs and config #24

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    install:
+        - requirements: docs/requirements.txt
+        - method: pip
+          path: .
+
+sphinx:
+    builder: html
+    configuration: docs/source/conf.py
+    # fail_on_warning: true

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+furo==2023.9.10
+myst-parser==2.0.0
+Sphinx==7.2.6
+sphinx-copybutton==0.5.2
+sphinx_inline_tabs==2023.4.21

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,67 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "Django Tag Me"
+copyright = "2023, Mark Sevelj"
+author = "Mark Sevelj"
+
+__version__ = "0.1.0"
+# The full version, including alpha/beta/rc tags.
+release = __version__
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = []
+
+templates_path = ["_templates"]
+extensions = [
+    "sphinx.ext.intersphinx",
+    "myst_parser",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx_copybutton",
+    "sphinx_inline_tabs",
+    "sphinx.ext.todo",
+]
+
+exclude_patterns = ["_build", "build", "Thumbs.db", ".DS_Store"]
+
+intersphinx_mapping = {
+    "django": (
+        "https://docs.djangoproject.com/en/stable",
+        "https://docs.djangoproject.com/en/stable/_objects/",
+    ),
+    "python": ("https://docs.python.org/3", None),
+}
+
+pygments_style = "monokai"
+pygments_dark_style = "monokai"
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "furo"
+html_static_path = ["_static"]
+
+# sphinx-copybutton is a lightweight code-block copy button
+# config options are here https://sphinx-copybutton.readthedocs.io/en/latest/
+# This config removes Python Repl + continuation, Bash line prefixes,
+# ipython and qtconsole + continuation, jupyter-console + continuation and preceding line numbers
+copybutton_prompt_text = (
+    r"^\d{1,4}|^.\d{1,4}|>>> |\s{2,6}|\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}:"
+)
+
+copybutton_prompt_is_regexp = True
+
+# datalad download-url http://www.tldp.org/LDP/Bash-Beginners-Guide/Bash-Beginners-Guide.pdf \
+# --dataset . \
+# -m "add beginners guide on bash" \
+# -O books/bash_guide.pdf
+# is correctly pasted with the following setting
+copybutton_line_continuation_character = "\\"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,22 @@
+.. Django Tag Me documentation master file, created by
+   sphinx-quickstart on Mon Sep 25 16:31:20 2023.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Django Tag Me's documentation!
+=========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
+
+.. include:: ../../README.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,8 @@ Tracker = "https://github.com/imAsparky/django-tag-me/issues"
 
 [tool.coverage.run]
 omit=[
-
   'tests/test_*.py',
   # '*/migrations/*'
-
-
-
 ]
 
 [tool.semantic_release]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 
-
+-r docs/requirements.txt
 # Test deps, relocate later.
 coverage==7.0.2
 dj-inmemorystorage==2.1.0


### PR DESCRIPTION
Create the docs folder and sphinx project with separate source and build folders.

Split out requirements into docs/requirements and add include with -r in project requirements.

Add README to the index page.

Add `.readthedocs.yaml` file for doc builds.

Add initial config in conf.py.

Uses `furo`, `copybutton` and `monokai pygments`.

Includes `intersphinx` mapping to `python` and `django`.

closes #24