### PR TITLE
docs(badge): Add docs badge, fix .yaml #26

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,10 +4,12 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-    install:
-        - requirements: docs/requirements.txt
-        - method: pip
-          path: .
+
+python:
+  install:
+      - requirements: docs/requirements.txt
+      - method: pip
+        path: .
 
 sphinx:
     builder: html

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,9 @@
 .. image:: https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg
    :target: https://python-semantic-release.readthedocs.io/en/latest/
    :alt: Python Semantic Release
+.. image:: https://readthedocs.org/projects/django-tag-me/badge/?version=latest
+   :target: https://django-tag-me.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status
 
 |
 


### PR DESCRIPTION
`.readthedocs.yaml` had a typo, this commit fixes that.

Add a readthedocs badge.

closes #26