### PR TITLE
fix(init): Move choice conversion to init #109

### DIFF
--- a/tests/test_custom_commands.py
+++ b/tests/test_custom_commands.py
@@ -14,6 +14,7 @@ class TestCustomManagementCommands(TestCase):
 
         assert "Updating Tagged Models Table." in self.out_migration.getvalue()
         assert (
-            "SUCCESS: Tagged Models Table updated."
+            "    SUCCESS: Tagged Models Table,"
+            " and Synchronised Fields updated."
             in self.out_migration.getvalue()
         )


### PR DESCRIPTION
Conversion of choices to FieldTagListFormatter moved to init.
Testing TagMeCharfield, in some cases a model for meta data does not exist, added a fix by testing for model attr in formfield override.

Removed redundant tests.
Updated broken tests due to minor changes in the code.

closes #108

closes #109